### PR TITLE
Update to Qt6 and bump included packages 

### DIFF
--- a/.github/workflows/build_stable.yml
+++ b/.github/workflows/build_stable.yml
@@ -14,24 +14,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-10.15, ubuntu-18.04, windows-2019]
+        os: [macos-11, windows-2019]
     steps:
 
     - name: Checkout code
       uses: actions/checkout@v2
 
-    # Not all dependencies work correctly on Python 3.9 on Windows yet so we use
-    # Python 3.8 there.
-    - name: Set up Python 3.8
-      if: matrix.os == 'windows-2019'
+    - name: Set up Python 3.11
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
-    - name: Set up Python 3.9
-      if: matrix.os != 'windows-2019'
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.9
+        python-version: 3.11
 
     - name: Install Python dependencies
       run: pip install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,13 @@
 git+https://github.com/pyinstaller/pyinstaller
 ipykernel<6  # Install old version of ipykernel to avoid terminal issues
-glue-core==1.7.0
+glue-core==1.8.0
 glue-vispy-viewers==1.0.7
 glue-wwt==0.6.1
 glue-plotly==0.4.0
-pvextractor
-pywwt
+pvextractor==0.3
+pywwt==0.19.0
 notebook
 numpy<1.22
 astropy<5.0
-PyQt5==5.14.2
-PyQtWebEngine==5.14.0
+PyQt6==6.4.2
+PyQt6-WebEngine==6.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 git+https://github.com/pyinstaller/pyinstaller
 ipykernel<6  # Install old version of ipykernel to avoid terminal issues
-glue-core==1.8.0
+glue-core==1.8.1
 glue-vispy-viewers==1.0.7
 glue-wwt==0.6.1
 glue-plotly==0.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-git+https://github.com/pyinstaller/pyinstaller
-ipykernel<6  # Install old version of ipykernel to avoid terminal issues
+pyinstaller
 glue-core==1.8.1
 glue-vispy-viewers==1.0.7
 glue-wwt==0.6.1
@@ -7,7 +6,5 @@ glue-plotly==0.4.0
 pvextractor==0.3
 pywwt==0.19.0
 notebook
-numpy<1.22
-astropy<5.0
 PyQt6==6.4.2
 PyQt6-WebEngine==6.4.0


### PR DESCRIPTION
This also removes the Linux builds since they don't work some of the time, and installation isn't as much of an issue on Linux.