### PR TITLE
Add h5py to standalone executable

### DIFF
--- a/glue_app.spec
+++ b/glue_app.spec
@@ -40,6 +40,7 @@ a = Analysis(
         "glue_wwt",
         "glue_plotly",
         "glue_statistics",
+        "h5py",
         "pvextractor",
         "PyQt6.QtTest",
     ],

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ glue-qt>=0.3.1
 glue-vispy-viewers
 glue-wwt>=0.7.2
 glue-plotly
+h5py
 pvextractor
 pywwt
 notebook


### PR DESCRIPTION
It was noticed that HDF5 files can't be opened using the standalone executables as `h5py` is not included in the application bundle. This PR aims to fix that.