### PR TITLE
Add pyavm to standalone executable

### DIFF
--- a/glue_app.spec
+++ b/glue_app.spec
@@ -40,6 +40,7 @@ a = Analysis(
         "glue_wwt",
         "glue_plotly",
         "glue_statistics",
+        "pyavm",
         "pvextractor",
         "PyQt6.QtTest",
     ],

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ glue-vispy-viewers
 glue-wwt>=0.7.2
 glue-plotly
 pvextractor
+pyavm
 pywwt
 notebook
 PyQt6==6.6.*


### PR DESCRIPTION
Following the same idea as #16, this PR adds `pyavm` to the standalone executable.
