### PR TITLE
Switch to PySide6 for App Store version

### DIFF
--- a/.github/workflows/build_stable.yml
+++ b/.github/workflows/build_stable.yml
@@ -283,8 +283,13 @@ jobs:
     - name: Simple test of MacOS X application
       run: dist/glue.app/Contents/MacOS/start_glue --test
 
+    # Use a fixed bundle name (not the branch/tag) so the app always installs to
+    # /Applications/glueviz.app and the App Store updates it in place across
+    # versions. The version is carried by CFBundleShortVersionString, and the
+    # versioned name is kept only on the .pkg artifact below. This matches
+    # CFBundleName / CFBundleDisplayName ("glueviz").
     - name: Rename MacOS X application
-      run: mv dist/glue.app dist/"glue ${BRANCH_NAME}.app"
+      run: mv dist/glue.app dist/glueviz.app
 
     - name: Remove start_glue
       run: rm -rf dist/start_glue
@@ -292,13 +297,13 @@ jobs:
     - name: Sign application for the App Store
       run: |
         osx/sign_app_store.sh \
-          dist/"glue ${BRANCH_NAME}.app" \
+          dist/glueviz.app \
           "${{ secrets.MAC_APP_DISTRIBUTION }}" \
           "${{ secrets.TEAM_ID }}" \
           io.gluesolutions.glueviz
 
     - name: Build MacOS X installer for distribution
-      run: productbuild --component dist/"glue ${BRANCH_NAME}.app" /Applications dist/"glue ${BRANCH_NAME}_unsigned.pkg"
+      run: productbuild --component dist/glueviz.app /Applications dist/"glue ${BRANCH_NAME}_unsigned.pkg"
 
     - name: Sign MacOS X installer for distribution
       shell: bash

--- a/.github/workflows/build_stable.yml
+++ b/.github/workflows/build_stable.yml
@@ -160,8 +160,9 @@ jobs:
   # This is a separate, sandboxed build that is signed with the "Apple
   # Distribution" / "3rd Party Mac Developer Application" certificate and
   # packaged as a signed .pkg, rather than the notarized DMG produced above. It
-  # only runs on tag pushes so it does not slow down ordinary branch/PR builds,
-  # and it does not touch the DMG artifacts.
+  # runs on direct pushes to branches and tags, but not on pull requests (which
+  # do not have access to the signing secrets), and it does not touch the DMG
+  # artifacts.
   #
   # In addition to the secrets used by the DMG build it needs:
   #   MAC_APP_DIST_CERT / MAC_APP_DIST_PASSWORD
@@ -228,7 +229,10 @@ jobs:
     name: macos-appstore
     runs-on: macos-14
     needs: check_appstore_secrets
-    if: needs.check_appstore_secrets.outputs.available == 'true' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && github.repository == 'glue-viz/glue-standalone-apps'
+    # Runs on any direct push (branches and tags) but not on pull requests, which
+    # lack the signing secrets. github.event_name == 'push' covers both branch
+    # and tag pushes and excludes pull_request events.
+    if: needs.check_appstore_secrets.outputs.available == 'true' && github.event_name == 'push' && github.repository == 'glue-viz/glue-standalone-apps'
     steps:
 
     - name: Determine name of build

--- a/glue_app.spec
+++ b/glue_app.spec
@@ -49,7 +49,7 @@ a = Analysis(
         "pyavm",
         "pvextractor",
         "astrodendro",
-        "PyQt6.QtTest",
+        "PySide6.QtTest",
     ],
     hookspath=["hooks"],
     hooksconfig={
@@ -58,7 +58,8 @@ a = Analysis(
     runtime_hooks=[],
     excludes=[
         "tkinter",
-        "PyQt5.QtQml",
+        "PyQt5",
+        "PyQt6",
         "joblib",
     ],
     win_no_prefer_redirects=False,

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,10 +17,10 @@ pyavm
 astrodendro
 pywwt
 notebook
-PyQt6==6.6.*
-PyQt6-Qt6==6.6.*
-PyQt6-WebEngine==6.6.*
-PyQt6-WebEngine-Qt6==6.6.*
+# PySide6 (LGPL) rather than PyQt6 (GPL) so the bundle can be distributed on the
+# Mac App Store. The PySide6 meta-package pulls in PySide6-Essentials and
+# PySide6-Addons, the latter providing QtWebEngine (needed by glue-wwt).
+PySide6==6.6.*
 vispy==0.15.*
 
 # Pin matplotlib <3.10.9 so as to avoid an incompatibility with pyinstaller

--- a/start_glue.py
+++ b/start_glue.py
@@ -27,6 +27,23 @@ import mimetypes
 mimetypes.knownfiles = []
 mimetypes.init()
 
+# webbrowser.open() launches the default browser by spawning /usr/bin/open,
+# which the App Store sandbox blocks (it may not execute binaries outside the
+# bundle). Route URL opening through Qt's QDesktopServices, which uses
+# LaunchServices and is permitted in the sandbox. This also works fine for the
+# non-sandboxed DMG build.
+import webbrowser
+
+
+def _open_url_via_qt(url, *args, **kwargs):
+    from qtpy.QtCore import QUrl
+    from qtpy.QtGui import QDesktopServices
+
+    return QDesktopServices.openUrl(QUrl(url))
+
+
+webbrowser.open = _open_url_via_qt
+
 from pywwt import qt
 from glue import load_plugins
 from glue.logger import logger

--- a/start_glue.py
+++ b/start_glue.py
@@ -15,6 +15,18 @@ import time
 # binding that this bundle ships, before anything triggers a Qt import.
 os.environ["QT_API"] = "pyside6"
 
+# The macOS App Store sandbox denies reading the system mimetypes files such as
+# /etc/apache2/mime.types (they exist but live outside the sandbox container),
+# and Python's mimetypes.init() does not guard against the resulting
+# PermissionError - it propagates and crashes pywwt's local data server when the
+# WWT viewer opens. Initialise the database from the built-in type map only and
+# stop it reading any system files; pywwt registers the extra types it needs via
+# mimetypes.add_type.
+import mimetypes
+
+mimetypes.knownfiles = []
+mimetypes.init()
+
 from pywwt import qt
 from glue import load_plugins
 from glue.logger import logger

--- a/start_glue.py
+++ b/start_glue.py
@@ -11,6 +11,10 @@ for arg in sys.argv:
 import os
 import time
 
+# Force qtpy (and therefore glue, pywwt and vispy) to use PySide6, the LGPL
+# binding that this bundle ships, before anything triggers a Qt import.
+os.environ["QT_API"] = "pyside6"
+
 from pywwt import qt
 from glue import load_plugins
 from glue.logger import logger


### PR DESCRIPTION
This switches to PySide6 for the App Store version to avoid licensing issues. We may actually just want to switch the main DMG over to this too for consistency.